### PR TITLE
feat: adiciona hook ao usar item

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -461,7 +461,16 @@ export class OrdemItem extends Item {
 			const gmUsers = game.users.filter((u) => u.isGM).map((u) => u.id);
 			chatMessageData.whisper = [...new Set([...gmUsers, game.user.id])].flat();
 		}
-		ChatMessage.create(chatMessageData);
+		
+		const message = await ChatMessage.create(chatMessageData);
+
+		Hooks.callAll("ordemparanormal.itemUsed", {
+			item: this,
+			actor: this.actor,
+			token,
+			message,
+			chatMessageData,
+		});
 	}
 
 	/**


### PR DESCRIPTION
## Resumo

Adiciona o hook `ordemparanormal.itemUsed` após a criação do `ChatMessage` em `OrdemItem.roll()`.

O hook expõe um payload com:

* `item`
* `actor`
* `token`
* `message`
* `chatMessageData`

Isso permite que módulos companion integrem automações ao uso normal de itens sem precisar interceptar métodos internos ou depender do HTML do chat card.

## Motivação

Atualmente, módulos externos que querem reagir ao uso de um item precisam recorrer a estratégias frágeis, como interceptar métodos internos ou analisar o conteúdo renderizado do chat.

Com esse hook, o sistema passa a oferecer um ponto oficial e simples de integração logo após o item ser usado e a mensagem de chat ser criada.

## Exemplo de uso

```js
Hooks.on("ordemparanormal.itemUsed", ({ item, actor, token, message, chatMessageData }) => {
	console.log("Item usado:", item.name, actor?.name, token, message, chatMessageData);
});
```

## Impacto

A mudança não altera regras, UX, dependências ou o valor de retorno atual do método.

Ela apenas aguarda a criação do `ChatMessage` e emite o hook em seguida.

## Validação local

* `npm test` passou