### PR TITLE
Fix/v14 data schema compatibility

### DIFF
--- a/module/data/items/armament-data.mjs
+++ b/module/data/items/armament-data.mjs
@@ -10,7 +10,7 @@ export class ArmamentData extends foundry.abstract.TypeDataModel {
 				class: new fields.StringField({ initial: "fas" }),
 			}),
 			quantity: new fields.NumberField({ required: true, integer: true, initial: 1 }),
-			proficiency: new fields.NumberField({ required: true, integer: true, initial: 0 }),
+			proficiency: new fields.StringField({ initial: "" }),
 			types: new fields.SchemaField({
 				rangeType: new fields.SchemaField({
 					name: new fields.StringField({ initial: "" }),

--- a/module/data/items/armament-data.mjs
+++ b/module/data/items/armament-data.mjs
@@ -10,7 +10,7 @@ export class ArmamentData extends foundry.abstract.TypeDataModel {
 				class: new fields.StringField({ initial: "fas" }),
 			}),
 			quantity: new fields.NumberField({ required: true, integer: true, initial: 1 }),
-			proficiency: new fields.StringField({ initial: "" }),
+			proficiency: new fields.StringField({ required: true, initial: "" }),
 			types: new fields.SchemaField({
 				rangeType: new fields.SchemaField({
 					name: new fields.StringField({ initial: "" }),

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -57,22 +57,6 @@ export class OrdemActor extends Actor {
 	/** @override */
 	prepareBaseData() {
 		super.prepareBaseData();
-		// Data modifications in this step occur before processing embedded
-		// documents or derived data.
-		const actorData = this;
-		const systemData = actorData.system;
-
-		if (actorData.type == 'agent') {
-			this._prepareDataStatus(actorData, systemData);
-			this._prepareRituals(actorData);
-			this._prepareBaseSkills(systemData);
-			this._preparePatent(actorData);
-		}
-
-		// Calcular perícias para Ameaças também
-		if (actorData.type == 'threat') {
-			this._prepareBaseSkillsThreat(systemData);
-		}
 	}
 
 	/** @override */
@@ -182,11 +166,11 @@ export class OrdemActor extends Actor {
 		}
 
 		// 3. Executa a lógica padrão do sistema (hook prepareEmbeddedData)
-		if ( game.release.generation < 14 ) phase ??= 'initial';
-		if ( (this.system?.prepareEmbeddedData instanceof Function) && (phase === 'initial') ) {
+		if (game.release.generation < 14) phase ??= "initial";
+		if (this.system?.prepareEmbeddedData instanceof Function && phase === "initial") {
 			this.system.prepareEmbeddedData();
 		}
-		
+
 		// 4. Chama o método original para aplicar os valores já calculados
 		return super.applyActiveEffects(phase);
 	}

--- a/tests/unit/data/items.test.mjs
+++ b/tests/unit/data/items.test.mjs
@@ -47,6 +47,12 @@ describe("ArmamentData.defineSchema()", () => {
 		const data = { description: "test" };
 		expect(ArmamentData.migrateData(data)).toBe(data);
 	});
+
+	it("stores proficiency as a string enum", () => {
+		const schema = ArmamentData.defineSchema();
+
+		expect(schema.proficiency.constructor.name).toBe("StringField");
+	});
 });
 
 describe("GeneralEquipmentData.defineSchema()", () => {


### PR DESCRIPTION
Ajusta pequenos pontos de compatibilidade de dados para a branch `v14`.

Mudanças:

* remove uma sobrescrita obsoleta de `prepareBaseData` no documento de ator;
* ajusta o campo `proficiency` de armamento para ser armazenado como string;
* adiciona teste cobrindo o tipo do campo `proficiency`.

A mudança é focada em schema/preparação de dados e não altera regras do sistema.