### PR TITLE
fix(v14): restore skill totals and threat skill bonuses

### DIFF
--- a/module/data/actors/threat-data.mjs
+++ b/module/data/actors/threat-data.mjs
@@ -1,5 +1,3 @@
-import { calculateSkillProficiency } from "../../helpers/actor-calculations.mjs";
-
 const defaultAttrs = {
 	fighting: "str",
 	aim: "dex",
@@ -161,8 +159,6 @@ export class ThreatData extends foundry.abstract.TypeDataModel {
 				}
 
 				if (!skill.degree) skill.degree = { value: 0, label: "untrained" };
-
-				skill.degree.value = calculateSkillProficiency(skill.degree.label);
 
 				if (keySkill === "freeSkill" && skill.name) {
 					skill.label = skill.name;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -127,8 +127,9 @@ export class OrdemActorSheet extends api.HandlebarsApplicationMixin(sheets.Actor
 		});
 
 		// Prepara os dados do Agente e seus Items.
-		if (this.document.type == "agent") {
+		if (this.document.type === "agent") {
 			this._prepareItems(context);
+			context.skillTotals = this._prepareSkillTotals(context.system.skills);
 		}
 
 		return context;
@@ -365,6 +366,23 @@ export class OrdemActorSheet extends api.HandlebarsApplicationMixin(sheets.Actor
 		context.protection = protection.sort((a, b) => (a.sort || 0) - (b.sort || 0));
 		context.generalEquip = generalEquipment.sort((a, b) => (a.sort || 0) - (b.sort || 0));
 		context.armament = armament.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+	}
+
+	/**
+	 * Calculates skill totals for sheet display only.
+	 *
+	 * @param {Record<string, object>} skills Actor skills.
+	 * @returns {Record<string, number>} Skill totals indexed by skill key.
+	 */
+	_prepareSkillTotals(skills = {}) {
+		return Object.fromEntries(
+			Object.entries(skills).map(([key, skill]) => {
+				const degree = Number(skill.degree?.value ?? 0);
+				const modifier = Number(skill.mod ?? 0);
+
+				return [key, degree + modifier];
+			})
+		);
 	}
 
 	/**

--- a/templates/actor/parts/actor-skills.hbs
+++ b/templates/actor/parts/actor-skills.hbs
@@ -46,7 +46,7 @@
 					<div class="flex0" style="margin: 0 5px; display: flex; justify-content: center;">
 						<input
 							type="text"
-							value="{{numberFormat skill.value decimals=0 sign=true}}"
+							value="{{numberFormat (lookup @root.skillTotals key) decimals=0 sign=true}}"
 							readonly
 							style="width: 40px; text-align: center; border: none; font-weight: bold; background: rgba(0,0,0,0.05);"
 							title="Total (Treino + Bônus)"


### PR DESCRIPTION
## Summary

Fixes two skill-related regressions on the `v14` branch.

- Restores the displayed agent skill total using proficiency plus the manual modifier.
- Prevents editable threat skill bonuses from being overwritten during data preparation.

## Changes

- Adds display-only skill totals to the agent sheet context.
- Updates the agent skill template to display the calculated total.
- Preserves manually configured threat skill values across sheet rerenders.

## Testing

### Agent skills

- Trained +0 displays +5.
- Veteran +5 displays +15.
- Expert +5 displays +20.
- Skill rolls do not duplicate the manual modifier.

### Threat skills

- Skill bonuses can be increased and decreased.
- The configured value persists after rerendering and reopening the sheet.
- Skill rolls use the configured value.