### PR TITLE
fix(v14): restore threat skill proficiency import

### DIFF
--- a/module/data/actors/threat-data.mjs
+++ b/module/data/actors/threat-data.mjs
@@ -1,3 +1,5 @@
+import { calculateSkillProficiency } from "../../helpers/actor-calculations.mjs";
+
 const defaultAttrs = {
 	fighting: "str",
 	aim: "dex",


### PR DESCRIPTION
## Summary

Restores the missing `calculateSkillProficiency` import in `ThreatData`.

The function is still required to derive the skill bonus from `degree.label` when no manual override is set.

## Changes

- Restores the `calculateSkillProficiency` import in `threat-data.mjs`.
- Keeps the existing `degree.override` behavior unchanged.

## Testing

- Ran the complete test suite with `npm run test`.
- Verified label-derived skill values.
- Verified positive and zero overrides.
- Verified fallback behavior for invalid overrides.