### PR TITLE
fix(threat): use canonical default attributes for skills

### DIFF
--- a/module/data/actors/threat-data.mjs
+++ b/module/data/actors/threat-data.mjs
@@ -11,11 +11,11 @@ const defaultAttrs = {
 	freeSkill: "int",
 };
 
-function skillField() {
+function skillField(defaultAttr = "dex") {
 	const fields = foundry.data.fields;
 	return new fields.SchemaField({
 		value: new fields.NumberField({ required: true, integer: true, initial: 0 }),
-		attr: new fields.ArrayField(new fields.StringField(), { initial: ["dex"] }),
+		attr: new fields.ArrayField(new fields.StringField(), { initial: [defaultAttr] }),
 		degree: new fields.SchemaField({
 			label: new fields.StringField({ initial: "untrained" }),
 			// `value` is *derived* from `label` by default (calculateSkillProficiency),
@@ -87,13 +87,13 @@ export class ThreatData extends foundry.abstract.TypeDataModel {
 			}),
 			attacks: new fields.ObjectField({ initial: {} }),
 			skills: new fields.SchemaField({
-				fighting: skillField(),
-				aim: skillField(),
-				resilience: skillField(),
-				reflexes: skillField(),
-				will: skillField(),
-				initiative: skillField(),
-				perception: skillField(),
+				fighting: skillField(defaultAttrs.fighting),
+				aim: skillField(defaultAttrs.aim),
+				resilience: skillField(defaultAttrs.resilience),
+				reflexes: skillField(defaultAttrs.reflexes),
+				will: skillField(defaultAttrs.will),
+				initiative: skillField(defaultAttrs.initiative),
+				perception: skillField(defaultAttrs.perception),
 				freeSkill: freeSkillField(),
 			}),
 			elements: new fields.SchemaField({
@@ -204,6 +204,19 @@ export class ThreatData extends foundry.abstract.TypeDataModel {
 	}
 
 	static migrateData(data) {
+		if (data?.skills && typeof data.skills === "object") {
+			for (const [key, skill] of Object.entries(data.skills)) {
+				if (key === "freeSkill") continue;
+
+				const canonical = defaultAttrs[key];
+				if (!canonical || canonical === "dex") continue;
+
+				if (Array.isArray(skill?.attr) && skill.attr.length === 1 && skill.attr[0] === "dex") {
+					skill.attr = [canonical];
+				}
+			}
+		}
+
 		// Legacy threats wrote "Tamanho" to system.details.size (ghost path), but
 		// the schema only exposes size at top level. Lift the value back and drop
 		// the orphan key so cleanData stops discarding it on every save.
@@ -213,6 +226,7 @@ export class ThreatData extends foundry.abstract.TypeDataModel {
 		if (data?.details && data.details.size !== undefined) {
 			delete data.details.size;
 		}
+
 		return super.migrateData(data);
 	}
 }

--- a/module/tests/suites/actor-threat-extended.test.mjs
+++ b/module/tests/suites/actor-threat-extended.test.mjs
@@ -233,6 +233,32 @@ Hooks.once("quenchReady", (quench) => {
 					assert.equal(threat.system.attributes.hp.value, hpBefore - 5);
 				});
 			});
+
+			describe("ThreatData — canonical skill defaults", () => {
+				let threat;
+
+				before(async () => {
+					threat = await Actor.create({
+						name: "[Quench] Threat Skill Defaults",
+						type: "threat",
+					});
+				});
+
+				after(async () => {
+					await threat?.delete();
+				});
+
+				it("uses the canonical attribute for every built-in skill", () => {
+					assert.equal(threat.system.skills.fighting.attr[0], "str");
+					assert.equal(threat.system.skills.aim.attr[0], "dex");
+					assert.equal(threat.system.skills.resilience.attr[0], "vit");
+					assert.equal(threat.system.skills.reflexes.attr[0], "dex");
+					assert.equal(threat.system.skills.will.attr[0], "pre");
+					assert.equal(threat.system.skills.initiative.attr[0], "dex");
+					assert.equal(threat.system.skills.perception.attr[0], "pre");
+					assert.equal(threat.system.skills.freeSkill.attr[0], "int");
+				});
+			});
 		},
 		{ displayName: "OP | Threat: skills estendidas, elements, disturbingPresence, applyDamage" }
 	);

--- a/tests/unit/data/threat-data.test.mjs
+++ b/tests/unit/data/threat-data.test.mjs
@@ -96,6 +96,20 @@ describe("ThreatData.defineSchema()", () => {
 		expect(Object.keys(schema)).toContain("size");
 		expect(Object.keys(schema.details.fields)).not.toContain("size");
 	});
+
+	it("uses the canonical default attribute for each threat skill", () => {
+		const schema = ThreatData.defineSchema();
+		const skills = schema.skills.fields;
+
+		expect(skills.fighting.fields.attr.initial).toEqual(["str"]);
+		expect(skills.aim.fields.attr.initial).toEqual(["dex"]);
+		expect(skills.resilience.fields.attr.initial).toEqual(["vit"]);
+		expect(skills.reflexes.fields.attr.initial).toEqual(["dex"]);
+		expect(skills.will.fields.attr.initial).toEqual(["pre"]);
+		expect(skills.initiative.fields.attr.initial).toEqual(["dex"]);
+		expect(skills.perception.fields.attr.initial).toEqual(["pre"]);
+		expect(skills.freeSkill.fields.attr.initial).toEqual(["int"]);
+	});
 });
 
 describe("ThreatData.migrateData()", () => {
@@ -144,6 +158,44 @@ describe("ThreatData.migrateData()", () => {
 	it("handles missing details object without throwing", () => {
 		const data = { size: "" };
 		expect(() => ThreatData.migrateData(data)).not.toThrow();
+	});
+
+	it("heals legacy threat skills initialized with dex", () => {
+		const data = {
+			skills: {
+				fighting: { attr: ["dex"] },
+				aim: { attr: ["dex"] },
+				resilience: { attr: ["dex"] },
+				reflexes: { attr: ["dex"] },
+				will: { attr: ["dex"] },
+				initiative: { attr: ["dex"] },
+				perception: { attr: ["dex"] },
+			},
+		};
+
+		ThreatData.migrateData(data);
+
+		expect(data.skills.fighting.attr).toEqual(["str"]);
+		expect(data.skills.aim.attr).toEqual(["dex"]);
+		expect(data.skills.resilience.attr).toEqual(["vit"]);
+		expect(data.skills.reflexes.attr).toEqual(["dex"]);
+		expect(data.skills.will.attr).toEqual(["pre"]);
+		expect(data.skills.initiative.attr).toEqual(["dex"]);
+		expect(data.skills.perception.attr).toEqual(["pre"]);
+	});
+
+	it("preserves non-legacy custom attributes", () => {
+		const data = {
+			skills: {
+				fighting: { attr: ["pre"] },
+				resilience: { attr: ["str"] },
+			},
+		};
+
+		ThreatData.migrateData(data);
+
+		expect(data.skills.fighting.attr).toEqual(["pre"]);
+		expect(data.skills.resilience.attr).toEqual(["str"]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Corrige os atributos padrão das perícias de Ameaças.

O `ThreatData` inicializava todas as perícias com `attr: ["dex"]`, o que fazia com que o fallback de `defaultAttrs` nunca fosse aplicado para perícias como Luta, Fortitude, Vontade e Percepção.

Este PR:

- passa o atributo canônico de cada perícia diretamente para o schema;
- corrige Ameaças antigas que ainda possuem o valor legado `["dex"]`;
- preserva atributos customizados que não correspondem ao valor legado;
- adiciona testes unitários e de integração para evitar regressão.

## Expected defaults

- Fighting → `str`
- Aim → `dex`
- Resilience → `vit`
- Reflexes → `dex`
- Will → `pre`
- Initiative → `dex`
- Perception → `pre`
- Free Skill → `int`

## Tests

- Schema defaults for all Threat skills
- Legacy `dex` migration
- Preservation of custom attributes
- Fresh Threat creation with canonical skill attributes